### PR TITLE
feat: Add Splunk Observability Cloud Resources.

### DIFF
--- a/aws_eticloud_account_splunk-olly-cloud_main.tf
+++ b/aws_eticloud_account_splunk-olly-cloud_main.tf
@@ -1,0 +1,93 @@
+# -------------------------------------------------------------------
+# Terraform Configuration
+# -------------------------------------------------------------------
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod" # Set the correct bucket for the environment
+    key    = "terraform-state/aws/eticloud/signalfx-integration.tfstate" # Set the AWS Account name in key
+    region = "us-east-2"
+  }
+  required_providers {
+    signalfx = {
+      source = "splunk-terraform/signalfx"
+    }
+  }
+}
+
+# -------------------------------------------------------------------
+# Local Variables
+# -------------------------------------------------------------------
+locals {
+  account_name      = "eticloud" # Set AWS account name
+  environment       = "prod"     # Set environment (prod, staging, dev)
+  splunk_ingest_url = "https://ingest.us1.signalfx.com"
+  default_tags = {
+    ApplicationName  = "outshift_infrastructure"
+    CiscoMailAlias   = "eti-sre-admins@cisco.com"
+    Component        = "platform_2025"
+    Environment      = "${local.environment}"
+    Owner            = "ETI SRE Team"
+    Project          = "Outshift Platform Observability"
+    ResourceOwner    = "eti-sre-admin"
+    TerraformManaged = "true"
+  }
+}
+
+# -------------------------------------------------------------------
+# AWS Account Credentials and Provider
+# -------------------------------------------------------------------
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/${local.account_name}/terraform_admin"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+
+  default_tags {
+    tags = local.default_tags
+  }
+}
+
+# -------------------------------------------------------------------
+# Splunk Observability Credentials and Provider
+# -------------------------------------------------------------------
+provider "vault" {
+  alias     = "eticloud_teamsecrets"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/teamsecrets"
+}
+
+data "vault_generic_secret" "generic_user_splunk_credential" {
+  provider = vault.eticloud_teamsecrets
+  path     = "secret/generic_users/eti-sre-cicd.gen"
+}
+
+provider "signalfx" {
+  auth_token     = data.vault_generic_secret.generic_user_splunk_credential.data["outshift.signalfx.com_session_token"]
+  api_url        = "https://api.us1.signalfx.com"
+  custom_app_url = "https://outshift.signalfx.com"
+}
+
+# -------------------------------------------------------------------
+# Module to Create AWS Integration in Splunk Observability
+# -------------------------------------------------------------------
+module "signalfx-aws-integration" {
+  source                  = "../../../../modules/signalfx-aws-integration"
+  aws_account_name        = local.account_name
+  poll_rate               = 200
+  use_metric_streams_sync = false
+  providers = {
+    aws      = aws
+    signalfx = signalfx
+  }
+}

--- a/aws_outshift-common-dev_account_splunk-olly-cloud_main.tf
+++ b/aws_outshift-common-dev_account_splunk-olly-cloud_main.tf
@@ -1,0 +1,93 @@
+# -------------------------------------------------------------------
+# Terraform Configuration
+# -------------------------------------------------------------------
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod" # Set the correct bucket for the environment
+    key    = "terraform-state/aws/outshift-common-dev/signalfx-integration.tfstate" # Set the AWS Account name in key
+    region = "us-east-2"
+  }
+  required_providers {
+    signalfx = {
+      source = "splunk-terraform/signalfx"
+    }
+  }
+}
+
+# -------------------------------------------------------------------
+# Local Variables
+# -------------------------------------------------------------------
+locals {
+  account_name      = "outshift-common-dev" # Set AWS account name
+  environment       = "dev"     # Set environment (prod, staging, dev)
+  splunk_ingest_url = "https://ingest.us1.signalfx.com"
+  default_tags = {
+    ApplicationName  = "outshift_infrastructure"
+    CiscoMailAlias   = "eti-sre-admins@cisco.com"
+    Component        = "platform_2025"
+    Environment      = "${local.environment}"
+    Owner            = "ETI SRE Team"
+    Project          = "Outshift Platform Observability"
+    ResourceOwner    = "eti-sre-admin"
+    TerraformManaged = "true"
+  }
+}
+
+# -------------------------------------------------------------------
+# AWS Account Credentials and Provider
+# -------------------------------------------------------------------
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/${local.account_name}/terraform_admin"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+
+  default_tags {
+    tags = local.default_tags
+  }
+}
+
+# -------------------------------------------------------------------
+# Splunk Observability Credentials and Provider
+# -------------------------------------------------------------------
+provider "vault" {
+  alias     = "eticloud_teamsecrets"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/teamsecrets"
+}
+
+data "vault_generic_secret" "generic_user_splunk_credential" {
+  provider = vault.eticloud_teamsecrets
+  path     = "secret/generic_users/eti-sre-cicd.gen"
+}
+
+provider "signalfx" {
+  auth_token     = data.vault_generic_secret.generic_user_splunk_credential.data["outshift.signalfx.com_session_token"]
+  api_url        = "https://api.us1.signalfx.com"
+  custom_app_url = "https://outshift.signalfx.com"
+}
+
+# -------------------------------------------------------------------
+# Module to Create AWS Integration in Splunk Observability
+# -------------------------------------------------------------------
+module "signalfx-aws-integration" {
+  source                  = "../../../../modules/signalfx-aws-integration"
+  aws_account_name        = local.account_name
+  poll_rate               = 200
+  use_metric_streams_sync = false
+  providers = {
+    aws      = aws
+    signalfx = signalfx
+  }
+}

--- a/aws_outshift-common-prod_account_splunk-olly-cloud_main.tf
+++ b/aws_outshift-common-prod_account_splunk-olly-cloud_main.tf
@@ -1,0 +1,92 @@
+# -------------------------------------------------------------------
+# Terraform Configuration
+# -------------------------------------------------------------------
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod" # Set the correct bucket for the environment
+    key    = "terraform-state/aws/outshift-common-prod/signalfx-integration.tfstate" # Set the AWS Account name in key
+    region = "us-east-2"
+  }
+  required_providers {
+    signalfx = {
+      source = "splunk-terraform/signalfx"
+    }
+  }
+}
+
+# -------------------------------------------------------------------
+# Local Variables
+# -------------------------------------------------------------------
+locals {
+  account_name      = "outshift-common-prod" # Set AWS account name
+  environment       = "prod"     # Set environment (prod, staging, dev)
+  splunk_ingest_url = "https://ingest.us1.signalfx.com"
+  default_tags = {
+    ApplicationName  = "outshift_infrastructure"
+    CiscoMailAlias   = "eti-sre-admins@cisco.com"
+    Component        = "platform_2025"
+    Environment      = "${local.environment}"
+    Owner            = "ETI SRE Team"
+    Project          = "Outshift Platform Observability"
+    ResourceOwner    = "eti-sre-admin"
+    TerraformManaged = "true"
+  }
+}
+
+# -------------------------------------------------------------------
+# AWS Account Credentials and Provider
+# -------------------------------------------------------------------
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/${local.account_name}/terraform_admin"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+
+  default_tags {
+    tags = local.default_tags
+  }
+}
+
+# -------------------------------------------------------------------
+# Splunk Observability Credentials and Provider
+# -------------------------------------------------------------------
+provider "vault" {
+  alias     = "eticloud_teamsecrets"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/teamsecrets"
+}
+
+data "vault_generic_secret" "generic_user_splunk_credential" {
+  provider = vault.eticloud_teamsecrets
+  path     = "secret/generic_users/eti-sre-cicd.gen"
+}
+
+provider "signalfx" {
+  auth_token     = data.vault_generic_secret.generic_user_splunk_credential.data["outshift.signalfx.com_session_token"]
+  api_url        = "https://api.us1.signalfx.com"
+  custom_app_url = "https://outshift.signalfx.com"
+}
+
+# -------------------------------------------------------------------
+# Module to Create AWS Integration in Splunk Observability
+# -------------------------------------------------------------------
+module "signalfx-aws-integration" {
+  source                  = "../../../../modules/signalfx-aws-integration"
+  aws_account_name        = local.account_name
+  use_metric_streams_sync = true
+  providers = {
+    aws      = aws
+    signalfx = signalfx
+  }
+}

--- a/aws_outshift-common-prod_account_splunk-olly-cloud_metric_stream_us-east-1.tf
+++ b/aws_outshift-common-prod_account_splunk-olly-cloud_metric_stream_us-east-1.tf
@@ -1,0 +1,21 @@
+# Infra AWS Provider
+provider "aws" {
+  alias       = "us-east-1"
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-1"
+  max_retries = 3
+
+  default_tags {
+    tags = local.default_tags
+  }
+}
+
+module "cloudwatch_metric_stream_us-east-1" {
+  source              = "../../../../modules/cloudwatch-metric-stream"
+  splunk_ingest_url   = local.splunk_ingest_url
+  splunk_access_token = data.vault_generic_secret.generic_user_splunk_credential.data["outshift.signalfx.com_session_token"]
+  providers = {
+    aws = aws.us-east-1
+  }
+}

--- a/aws_outshift-common-prod_account_splunk-olly-cloud_metric_stream_us-east-2.tf
+++ b/aws_outshift-common-prod_account_splunk-olly-cloud_metric_stream_us-east-2.tf
@@ -1,0 +1,21 @@
+# Infra AWS Provider
+provider "aws" {
+  alias       = "us-east-2"
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+
+  default_tags {
+    tags = local.default_tags
+  }
+}
+
+module "cloudwatch_metric_stream_us-east-2" {
+  source              = "../../../../modules/cloudwatch-metric-stream"
+  splunk_ingest_url   = local.splunk_ingest_url
+  splunk_access_token = data.vault_generic_secret.generic_user_splunk_credential.data["outshift.signalfx.com_session_token"]
+  providers = {
+    aws = aws.us-east-2
+  }
+}

--- a/aws_outshift-common-prod_account_splunk-olly-cloud_metric_stream_us-west-2.tf
+++ b/aws_outshift-common-prod_account_splunk-olly-cloud_metric_stream_us-west-2.tf
@@ -1,0 +1,21 @@
+# Infra AWS Provider
+provider "aws" {
+  alias       = "us-west-2"
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-west-2"
+  max_retries = 3
+
+  default_tags {
+    tags = local.default_tags
+  }
+}
+
+module "cloudwatch_metric_stream_us-west-2" {
+  source              = "../../../../modules/cloudwatch-metric-stream"
+  splunk_ingest_url   = local.splunk_ingest_url
+  splunk_access_token = data.vault_generic_secret.generic_user_splunk_credential.data["outshift.signalfx.com_session_token"]
+  providers = {
+    aws = aws.us-west-2
+  }
+}

--- a/aws_outshift-common-staging_account_splunk-olly-cloud_main.tf
+++ b/aws_outshift-common-staging_account_splunk-olly-cloud_main.tf
@@ -1,0 +1,93 @@
+# -------------------------------------------------------------------
+# Terraform Configuration
+# -------------------------------------------------------------------
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod" # Set the correct bucket for the environment
+    key    = "terraform-state/aws/outshift-common-staging/signalfx-integration.tfstate" # Set the AWS Account name in key
+    region = "us-east-2"
+  }
+  required_providers {
+    signalfx = {
+      source = "splunk-terraform/signalfx"
+    }
+  }
+}
+
+# -------------------------------------------------------------------
+# Local Variables
+# -------------------------------------------------------------------
+locals {
+  account_name      = "outshift-common-staging" # Set AWS account name
+  environment       = "staging"     # Set environment (prod, staging, dev)
+  splunk_ingest_url = "https://ingest.us1.signalfx.com"
+  default_tags = {
+    ApplicationName  = "outshift_infrastructure"
+    CiscoMailAlias   = "eti-sre-admins@cisco.com"
+    Component        = "platform_2025"
+    Environment      = "${local.environment}"
+    Owner            = "ETI SRE Team"
+    Project          = "Outshift Platform Observability"
+    ResourceOwner    = "eti-sre-admin"
+    TerraformManaged = "true"
+  }
+}
+
+# -------------------------------------------------------------------
+# AWS Account Credentials and Provider
+# -------------------------------------------------------------------
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/${local.account_name}/terraform_admin"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+
+  default_tags {
+    tags = local.default_tags
+  }
+}
+
+# -------------------------------------------------------------------
+# Splunk Observability Credentials and Provider
+# -------------------------------------------------------------------
+provider "vault" {
+  alias     = "eticloud_teamsecrets"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/teamsecrets"
+}
+
+data "vault_generic_secret" "generic_user_splunk_credential" {
+  provider = vault.eticloud_teamsecrets
+  path     = "secret/generic_users/eti-sre-cicd.gen"
+}
+
+provider "signalfx" {
+  auth_token     = data.vault_generic_secret.generic_user_splunk_credential.data["outshift.signalfx.com_session_token"]
+  api_url        = "https://api.us1.signalfx.com"
+  custom_app_url = "https://outshift.signalfx.com"
+}
+
+# -------------------------------------------------------------------
+# Module to Create AWS Integration in Splunk Observability
+# -------------------------------------------------------------------
+module "signalfx-aws-integration" {
+  source                  = "../../../../modules/signalfx-aws-integration"
+  aws_account_name        = local.account_name
+  poll_rate               = 200
+  use_metric_streams_sync = false
+  providers = {
+    aws      = aws
+    signalfx = signalfx
+  }
+}

--- a/modules_cloudwatch-metric-stream_main.tf
+++ b/modules_cloudwatch-metric-stream_main.tf
@@ -1,0 +1,171 @@
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+}
+
+# Resources
+resource "aws_s3_bucket" "splunk_metric_streams_s3" {
+  bucket = "splunk-metric-streams-s3-${local.account_id}-${data.aws_region.current.name}"
+}
+
+resource "aws_cloudwatch_log_group" "splunk_metric_streams_kinesis_firehose_log_group" {
+  name              = "/aws/kinesisfirehose/splunk-metric-streams-${data.aws_region.current.name}"
+  retention_in_days = 14
+}
+
+resource "aws_cloudwatch_log_stream" "splunk_metric_streams_kinesis_firehose_http_log_stream" {
+  name           = "HttpEndpointDelivery"
+  log_group_name = aws_cloudwatch_log_group.splunk_metric_streams_kinesis_firehose_log_group.name
+}
+
+resource "aws_iam_role" "splunk_metric_streams_s3_role" {
+  name = "splunk-metric-streams-s3-${data.aws_region.current.name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "firehose.amazonaws.com",
+        },
+        Action = "sts:AssumeRole",
+      },
+    ],
+  })
+
+  tags = {
+    Name = "splunk-metric-streams-s3",
+  }
+}
+
+resource "aws_iam_role_policy" "s3_firehose_policy" {
+  name = "s3_firehose"
+  role = aws_iam_role.splunk_metric_streams_s3_role.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = [
+          "logs:PutLogEvents"
+        ],
+        Resource = "${aws_cloudwatch_log_group.splunk_metric_streams_kinesis_firehose_log_group.arn}:*",
+        Effect   = "Allow"
+      },
+      {
+        Action = [
+          "s3:AbortMultipartUpload",
+          "s3:GetBucketLocation",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:ListBucketMultipartUploads",
+          "s3:PutObject"
+        ],
+        Resource = [
+          "${aws_s3_bucket.splunk_metric_streams_s3.arn}",
+          "${aws_s3_bucket.splunk_metric_streams_s3.arn}/*"
+        ],
+        Effect = "Allow"
+      }
+    ],
+  })
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "splunk_metric_streams_kinesis_firehose" {
+  name        = "splunk-metric-streams-${data.aws_region.current.name}"
+  destination = "http_endpoint"
+
+  http_endpoint_configuration {
+    url        = "${var.splunk_ingest_url}/v1/cloudwatch_metric_stream"
+    role_arn   = aws_iam_role.splunk_metric_streams_s3_role.arn
+    access_key = var.splunk_access_token
+    name       = "Splunk"
+
+    buffering_size     = 1
+    buffering_interval = 60
+
+    request_configuration {
+      content_encoding = "GZIP"
+    }
+
+    s3_backup_mode = "FailedDataOnly"
+
+    s3_configuration {
+      bucket_arn         = aws_s3_bucket.splunk_metric_streams_s3.arn
+      compression_format = "GZIP"
+      role_arn           = aws_iam_role.splunk_metric_streams_s3_role.arn
+
+      cloudwatch_logging_options {
+        enabled         = true
+        log_group_name  = aws_cloudwatch_log_group.splunk_metric_streams_kinesis_firehose_log_group.name
+        log_stream_name = aws_cloudwatch_log_stream.splunk_metric_streams_kinesis_firehose_http_log_stream.name
+      }
+    }
+
+    cloudwatch_logging_options {
+      enabled         = true
+      log_group_name  = aws_cloudwatch_log_group.splunk_metric_streams_kinesis_firehose_log_group.name
+      log_stream_name = aws_cloudwatch_log_stream.splunk_metric_streams_kinesis_firehose_http_log_stream.name
+    }
+  }
+  tags = {
+    splunk-metric-streams-firehose = data.aws_region.current.name
+  }
+
+
+}
+
+resource "aws_iam_role" "splunk_metric_stream_role" {
+  name = "splunk-metric-streams-${data.aws_region.current.name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "streams.metrics.cloudwatch.amazonaws.com",
+        },
+        Action = "sts:AssumeRole",
+      },
+    ],
+  })
+
+  path = "/"
+
+  description = "A role that allows CloudWatch MetricStreams to publish to Kinesis Firehose"
+
+  tags = {
+    splunk-metric-streams-role = data.aws_region.current.name
+  }
+
+}
+
+resource "aws_iam_role_policy" "firehose_put_policy" {
+  name = "firehose_put"
+  role = aws_iam_role.splunk_metric_stream_role.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "firehose:PutRecord",
+          "firehose:PutRecordBatch",
+        ],
+        Resource = aws_kinesis_firehose_delivery_stream.splunk_metric_streams_kinesis_firehose.arn,
+      },
+    ],
+  })
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/modules_cloudwatch-metric-stream_variables.tf
+++ b/modules_cloudwatch-metric-stream_variables.tf
@@ -1,0 +1,9 @@
+variable splunk_access_token {
+  description = "Copy your Splunk Observability access token with INGEST authorization scope from Settings > Access Tokens."
+  type = string
+}
+
+variable splunk_ingest_url {
+  description = "Find the real-time data ingest URL in Profile > Account Settings > Endpoints. Note: do NOT include endpoint path here: for instance use https://ingest.us1.signalfx.com instead of https://ingest.us1.signalfx.com/v1/cloudwatch_metric_stream."
+  type = string
+}

--- a/modules_signalfx-aws-integration_main.tf
+++ b/modules_signalfx-aws-integration_main.tf
@@ -1,0 +1,187 @@
+resource "signalfx_aws_external_integration" "aws_outshift_extern" {
+  name = "${var.aws_account_name} (${data.aws_caller_identity.current.account_id})"
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "signalfx_assume_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [signalfx_aws_external_integration.aws_outshift_extern.signalfx_aws_account]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values   = [signalfx_aws_external_integration.aws_outshift_extern.external_id]
+    }
+  }
+}
+
+resource "aws_iam_role" "aws_signalfx_role" {
+  name               = "Signalfx_CloudWatch_Access_Role"
+  description        = "Signalfx(Splunk Observability Cloud) integration to read out data and send it to signalfxs aws account"
+  assume_role_policy = data.aws_iam_policy_document.signalfx_assume_policy.json
+}
+
+resource "aws_iam_policy" "aws_signalfx_policy" {
+  name        = "SplunkObservabilityPolicy"
+  description = "AWS permissions required by the Splunk Observability Cloud"
+  policy      = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "airflow:GetEnvironment",
+        "airflow:ListEnvironments",
+        "apigateway:GET",
+        "autoscaling:DescribeAutoScalingGroups",
+        "cloudformation:ListResources",
+        "cloudformation:GetResource",
+        "cloudfront:GetDistributionConfig",
+        "cloudfront:ListDistributions",
+        "cloudfront:ListTagsForResource",
+        "cloudwatch:GetMetricData",
+        "cloudwatch:ListMetrics",
+        "cloudwatch:ListMetricStreams",
+        "cloudwatch:GetMetricStream",
+        "cloudwatch:PutMetricStream",
+        "cloudwatch:DeleteMetricStream",
+        "cloudwatch:StartMetricStreams",
+        "cloudwatch:StopMetricStreams",
+        "directconnect:DescribeConnections",
+        "dynamodb:DescribeTable",
+        "dynamodb:ListTables",
+        "dynamodb:ListTagsOfResource",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeNatGateways",
+        "ec2:DescribeRegions",
+        "ec2:DescribeReservedInstances",
+        "ec2:DescribeReservedInstancesModifications",
+        "ec2:DescribeTags",
+        "ec2:DescribeVolumes",
+        "ecs:DescribeClusters",
+        "ecs:DescribeServices",
+        "ecs:DescribeTasks",
+        "ecs:ListClusters",
+        "ecs:ListServices",
+        "ecs:ListTagsForResource",
+        "ecs:ListTaskDefinitions",
+        "ecs:ListTasks",
+        "eks:DescribeCluster",
+        "eks:ListClusters",
+        "elasticache:DescribeCacheClusters",
+        "elasticloadbalancing:DescribeLoadBalancerAttributes",
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeTags",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticmapreduce:DescribeCluster",
+        "elasticmapreduce:ListClusters",
+        "es:DescribeElasticsearchDomain",
+        "es:ListDomainNames",
+        "iam:listAccountAliases",
+        "iam:PassRole",
+        "kafka:DescribeCluster",
+        "kafka:DescribeClusterV2",
+        "kafka:ListClusters",
+        "kafka:ListClustersV2",
+        "kinesis:DescribeStream",
+        "kinesis:ListShards",
+        "kinesis:ListStreams",
+        "kinesis:ListTagsForStream",
+        "kinesisanalytics:DescribeApplication",
+        "kinesisanalytics:ListApplications",
+        "kinesisanalytics:ListTagsForResource",
+        "lambda:GetAlias",
+        "lambda:ListFunctions",
+        "lambda:ListTags",
+        "logs:DeleteSubscriptionFilter",
+        "logs:DescribeLogGroups",
+        "logs:DescribeSubscriptionFilters",
+        "logs:PutSubscriptionFilter",
+        "network-firewall:DescribeFirewall",
+        "network-firewall:ListFirewalls",
+        "organizations:DescribeOrganization",
+        "rds:DescribeDBInstances",
+        "rds:DescribeDBClusters",
+        "rds:ListTagsForResource",
+        "redshift:DescribeClusters",
+        "redshift:DescribeLoggingStatus",
+        "s3:GetBucketLocation",
+        "s3:GetBucketLogging",
+        "s3:GetBucketNotification",
+        "s3:GetBucketTagging",
+        "s3:ListAllMyBuckets",
+        "s3:ListBucket",
+        "s3:PutBucketNotification",
+        "sqs:GetQueueAttributes",
+        "sqs:ListQueues",
+        "sqs:ListQueueTags",
+        "states:ListActivities",
+        "states:ListStateMachines",
+        "tag:GetResources",
+        "workspaces:DescribeWorkspaces"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cassandra:Select"
+      ],
+      "Resource": [
+        "arn:aws:cassandra:*:*:/keyspace/system/table/local",
+        "arn:aws:cassandra:*:*:/keyspace/system/table/peers",
+        "arn:aws:cassandra:*:*:/keyspace/system_schema/*",
+        "arn:aws:cassandra:*:*:/keyspace/system_schema_mcs/table/tags",
+        "arn:aws:cassandra:*:*:/keyspace/system_schema_mcs/table/tables",
+        "arn:aws:cassandra:*:*:/keyspace/system_schema_mcs/table/columns"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "splunk_role_policy_attach" {
+  role       = aws_iam_role.aws_signalfx_role.name
+  policy_arn = aws_iam_policy.aws_signalfx_policy.arn
+}
+
+resource "time_sleep" "iam_policy_available" {
+  depends_on      = [aws_iam_role_policy_attachment.splunk_role_policy_attach]
+  create_duration = "15s"
+}
+
+resource "signalfx_aws_integration" "aws_outshift" {
+  enabled = true
+
+  integration_id          = signalfx_aws_external_integration.aws_outshift_extern.id
+  external_id             = signalfx_aws_external_integration.aws_outshift_extern.external_id
+  role_arn                = aws_iam_role.aws_signalfx_role.arn
+  regions                 = var.splunk_aws_regions
+  poll_rate               = var.poll_rate
+  use_metric_streams_sync = var.use_metric_streams_sync
+  import_cloud_watch      = true
+  enable_aws_usage        = true
+  depends_on = [
+    time_sleep.iam_policy_available
+  ]
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    signalfx = {
+      source = "splunk-terraform/signalfx"
+    }
+  }
+}

--- a/modules_signalfx-aws-integration_variables.tf
+++ b/modules_signalfx-aws-integration_variables.tf
@@ -1,0 +1,39 @@
+variable "splunk_aws_regions" {
+  description = "List of AWS regions to enable the Splunk AWS integration in."
+  type        = list(string)
+  default = [
+    "us-east-2",
+    "ap-northeast-1",
+    "ap-northeast-2",
+    "ap-northeast-3",
+    "ap-south-1",
+    "ap-southeast-1",
+    "ap-southeast-2",
+    "ca-central-1",
+    "eu-central-1",
+    "eu-north-1",
+    "eu-west-1",
+    "eu-west-2",
+    "eu-west-3",
+    "sa-east-1",
+    "us-east-1",
+    "us-west-1",
+    "us-west-2",
+  ]
+}
+
+variable "aws_account_name" {
+  description = "Name of the AWS account to be used for the Splunk AWS integration."
+  type        = string
+}
+variable "use_metric_streams_sync" {
+  description = "Flag to enable the use of metric streams for the Splunk AWS integration."
+  type        = bool
+  default     = false
+}
+
+variable "poll_rate" {
+  description = "Polling interval for the Splunk AWS integration."
+  type        = number
+  default     = 200
+}

--- a/splunk_outshift_signalfx_com_detectors_OPEng_detector_foo.tf
+++ b/splunk_outshift_signalfx_com_detectors_OPEng_detector_foo.tf
@@ -1,0 +1,26 @@
+resource "signalfx_detector" "application_delay" {
+  count        = length(var.clusters)
+  name         = " max average delay - ${var.clusters[count.index]}"
+  description  = "your application is slow - ${var.clusters[count.index]}"
+  max_delay    = 30
+  program_text = <<-EOF
+        signal = data('app.delay', filter('cluster','${var.clusters[count.index]}'), extrapolation='last_value', maxExtrapolations=5).max()
+        detect(when(signal > 60, '5m')).publish('Processing old messages 5m')
+        detect(when(signal > 60, '30m')).publish('Processing old messages 30m')
+    EOF
+  rule {
+    description   = "maximum > 60 for 5m"
+    severity      = "Warning"
+    detect_label  = "Processing old messages 5m"
+    notifications = ["Email,foo-alerts@bar.com"]
+  }
+  rule {
+    description   = "maximum > 60 for 30m"
+    severity      = "Critical"
+    detect_label  = "Processing old messages 30m"
+    notifications = ["Email,foo-alerts@bar.com"]
+  }
+}
+variable "clusters" {
+  default = ["clusterA", "clusterB"]
+}

--- a/splunk_outshift_signalfx_com_detectors_OPEng_main.tf
+++ b/splunk_outshift_signalfx_com_detectors_OPEng_main.tf
@@ -1,0 +1,42 @@
+# -------------------------------------------------------------------
+# Terraform Configuration
+# -------------------------------------------------------------------
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/signalfx/detectors-openg.tfstate"
+    region = "us-east-2"
+  }
+  required_providers {
+    signalfx = {
+      source = "splunk-terraform/signalfx"
+    }
+  }
+}
+
+# -------------------------------------------------------------------
+# Local Variables
+# -------------------------------------------------------------------
+locals {
+  splunk_ingest_url = "https://ingest.us1.signalfx.com"
+}
+
+# -------------------------------------------------------------------
+# Splunk Observability Credentials and Provider
+# -------------------------------------------------------------------
+provider "vault" {
+  alias     = "eticloud_teamsecrets"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/teamsecrets"
+}
+
+data "vault_generic_secret" "generic_user_splunk_credential" {
+  provider = vault.eticloud_teamsecrets
+  path     = "secret/generic_users/eti-sre-cicd.gen"
+}
+
+provider "signalfx" {
+  auth_token     = data.vault_generic_secret.generic_user_splunk_credential.data["outshift.signalfx.com_session_token"]
+  api_url        = "https://api.us1.signalfx.com"
+  custom_app_url = "https://outshift.signalfx.com"
+}

--- a/splunk_outshift_signalfx_com_integrations_PagerDuty_OPEng_integration.tf
+++ b/splunk_outshift_signalfx_com_integrations_PagerDuty_OPEng_integration.tf
@@ -1,0 +1,11 @@
+resource "signalfx_pagerduty_integration" "development-non-urgent" {
+  name    = "Development Non-urgent"
+  enabled = true
+  api_key = "40e4a734f86d400dc0396356ba1c8200"
+}
+
+resource "signalfx_pagerduty_integration" "urgent-pagerduty-service" {
+  name    = "SRE Urgent PagerDuty Service"
+  enabled = true
+  api_key = "6f1de70773124204c0fd20931fc1027c"
+}

--- a/splunk_outshift_signalfx_com_integrations_PagerDuty_OPEng_main.tf
+++ b/splunk_outshift_signalfx_com_integrations_PagerDuty_OPEng_main.tf
@@ -1,0 +1,42 @@
+# -------------------------------------------------------------------
+# Terraform Configuration
+# -------------------------------------------------------------------
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/signalfx/integration-pagerduty-openg.tfstate"
+    region = "us-east-2"
+  }
+  required_providers {
+    signalfx = {
+      source = "splunk-terraform/signalfx"
+    }
+  }
+}
+
+# -------------------------------------------------------------------
+# Local Variables
+# -------------------------------------------------------------------
+locals {
+  splunk_ingest_url = "https://ingest.us1.signalfx.com"
+}
+
+# -------------------------------------------------------------------
+# Splunk Observability Credentials and Provider
+# -------------------------------------------------------------------
+provider "vault" {
+  alias     = "eticloud_teamsecrets"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/teamsecrets"
+}
+
+data "vault_generic_secret" "generic_user_splunk_credential" {
+  provider = vault.eticloud_teamsecrets
+  path     = "secret/generic_users/eti-sre-cicd.gen"
+}
+
+provider "signalfx" {
+  auth_token     = data.vault_generic_secret.generic_user_splunk_credential.data["outshift.signalfx.com_session_token"]
+  api_url        = "https://api.us1.signalfx.com"
+  custom_app_url = "https://outshift.signalfx.com"
+}


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  


### Description/Justification

(Why is this change needed? Which team might need it? etc...)  

PagerDuty API Key field, is integration key like we store for alertmanager in helm chart values.

### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [ ] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
