### PR TITLE
fix(permisssions): do not allow to use root user

### DIFF
--- a/modules_sso-roles_data.tf
+++ b/modules_sso-roles_data.tf
@@ -19,15 +19,4 @@ data "aws_iam_policy_document" "assume_role_with_saml" {
       values   = ["https://signin.aws.amazon.com/saml"]
     }
   }
-
-  statement {
-    effect = "Allow"
-
-    actions = ["sts:AssumeRole"]
-    principals {
-      type = "AWS"
-
-      identifiers = ["arn:aws:iam::${local.account_id}:root"]
-    }
-  }
 }


### PR DESCRIPTION
root has all perms on a given AWS account

•	For each venture or project we create an IAM role
•	We grant that IAM role some permissions on AWS resources by way of existing IAM policies. Each venture can thus have its own set of permissions
•	Venture users (human) can login to AWS and assume that venture role.

Thus root isn't needed here.