### PR TITLE
chore: update phoenix hosted zone to use "dev.outshift.ai"

### DIFF
--- a/aws_eticloud_cdn_phoenix.dev.outshift.ai_dev_acm.tf
+++ b/aws_eticloud_cdn_phoenix.dev.outshift.ai_dev_acm.tf
@@ -10,7 +10,7 @@ locals {
 
 data "aws_route53_zone" "domain" {
   provider = aws.route53
-  name = "phoenix.dev.outshift.ai"
+  name = "dev.outshift.ai"
 }
 resource "aws_acm_certificate" "this" {
   provider = aws.us-east-1


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  


### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [ ] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
