### PR TITLE
fix: update DynamoDB service level policy

### DIFF
--- a/aws_outshift-common-dev_iam_roles_phoenix_zot-s3-dynamo-role.tf
+++ b/aws_outshift-common-dev_iam_roles_phoenix_zot-s3-dynamo-role.tf
@@ -3,37 +3,45 @@ resource "aws_iam_policy" "zot_s3_dynamo_policy" {
   name        = "zot-s3-dynamo-policy"
   description = "IAM Policy to grant permissions to phoenix s3 zot bucket"
   policy = jsonencode({
-    "Version": "2012-10-17",
-    "Statement": [
+    "Version" : "2012-10-17",
+    "Statement" : [
       {
-        "Effect": "Allow",
-        "Action": [
+        "Effect" : "Allow",
+        "Action" : [
           "s3:ListBucket",
           "s3:GetBucketLocation",
           "s3:ListBucketMultipartUploads"
         ],
-        "Resource": "arn:aws:s3:::outshift-zot-dev-bucket"
+        "Resource" : "arn:aws:s3:::outshift-zot-dev-bucket"
       },
       {
-        "Effect": "Allow",
-        "Action": [
+        "Effect" : "Allow",
+        "Action" : [
           "s3:PutObject",
           "s3:GetObject",
           "s3:DeleteObject",
           "s3:ListMultipartUploadParts",
           "s3:AbortMultipartUpload"
         ],
-        "Resource": "arn:aws:s3:::outshift-zot-dev-bucket/*"
+        "Resource" : "arn:aws:s3:::outshift-zot-dev-bucket/*"
       },
       {
-        "Effect": "Allow",
-        "Action": [
+        "Effect" : "Allow",
+        "Action" : [
           "dynamodb:CreateTable",
+          "dynamodb:DescribeTable",
+          "dynamodb:ListTables"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
           "dynamodb:GetItem",
           "dynamodb:UpdateItem",
           "dynamodb:DeleteItem"
         ],
-        "Resource": "arn:aws:dynamodb:*:*:table/ZotBlobTable"
+        "Resource" : "arn:aws:dynamodb:*:*:table/ZotBlobTable"
       }
     ]
   })


### PR DESCRIPTION
### Description/Justification
Modify policy for DynamoDB service


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [ ] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
