### PR TITLE
chore: move phoenix-ui s3 bucket from commn-dev to eticloud

### DIFF
--- a/aws_eticloud_us-east-1_s3_outshift-phoenix-project_main.tf
+++ b/aws_eticloud_us-east-1_s3_outshift-phoenix-project_main.tf
@@ -12,7 +12,7 @@ provider "vault" {
 }
 data "vault_generic_secret" "aws_infra_credential" {
   provider = vault.eticloud
-  path     = "secret/eticcprod/infra/prod/aws"
+  path     = "secret/infra/aws/eticloud/terraform_admin"
 }
 
 provider "aws" {

--- a/aws_eticloud_us-east-1_s3_outshift-phoenix-project_main.tf
+++ b/aws_eticloud_us-east-1_s3_outshift-phoenix-project_main.tf
@@ -1,0 +1,47 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"                                                       
+    key    = "terraform-state/aws-eticloud/s3/us-east-1/phoenix-ui.tfstate" 
+    region = "us-east-2"                                                                       
+  }
+}
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+  alias     = "eticloud"
+}
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/outshift-common-dev/terraform_admin"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-1"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "outshift_ventures"
+      Component          = "phoenix"
+      CiscoMailAlias     = "outshift-phoenix@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "outshift-phoenix-admins"
+
+      IntendedPublic = "False"
+    }
+  }
+}
+
+module "s3" {
+  source                = "git::https://github.com/cisco-eti/sre-tf-module-aws-s3.git?ref=1.0.3"
+  bucket_name           = "outshift-phoenix-ui"
+  CSBApplicationName    = "outshift_ventures"
+  CSBCiscoMailAlias     = "outshift-phoenix@cisco.com"
+  CSBDataClassification = "Cisco Confidential"
+  CSBDataTaxonomy       = "Cisco Operations Data"
+  CSBEnvironment        = "NonProd"
+  CSBResourceOwner      = "outshift-phoenix-admins"
+}

--- a/aws_eticloud_us-east-1_s3_outshift-phoenix-project_main.tf
+++ b/aws_eticloud_us-east-1_s3_outshift-phoenix-project_main.tf
@@ -12,7 +12,7 @@ provider "vault" {
 }
 data "vault_generic_secret" "aws_infra_credential" {
   provider = vault.eticloud
-  path     = "secret/infra/aws/eticloud/terraform_admin"
+  path     = "secret/eticcprod/infra/prod/aws"
 }
 
 provider "aws" {

--- a/aws_eticloud_us-east-1_s3_outshift-phoenix-project_main.tf
+++ b/aws_eticloud_us-east-1_s3_outshift-phoenix-project_main.tf
@@ -12,7 +12,7 @@ provider "vault" {
 }
 data "vault_generic_secret" "aws_infra_credential" {
   provider = vault.eticloud
-  path     = "secret/infra/aws/outshift-common-dev/terraform_admin"
+  path     = "secret/infra/aws/eticloud/terraform_admin"
 }
 
 provider "aws" {

--- a/aws_eticloud_us-east-2_s3_outshift-phoenix-project_main.tf
+++ b/aws_eticloud_us-east-2_s3_outshift-phoenix-project_main.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket = "eticloud-tf-state-nonprod"                                                       
-    key    = "terraform-state/aws-eticloud/s3/us-east-2/phoenix-ui.tfstate" 
+    key    = "terraform-state/aws-eticloud/s3/us-east-2/outshift-phoenix-ui.tfstate" 
     region = "us-east-2"                                                                       
   }
 }
@@ -36,8 +36,8 @@ provider "aws" {
 }
 
 module "s3" {
-  source                = "git::https://github.com/cisco-eti/sre-tf-module-aws-s3.git?ref=1.0.3"
-  bucket_name           = "phoenix-ui"
+  source                = "git::https://github.com/cisco-eti/sre-tf-module-aws-s3.git?ref=1.0.2"
+  bucket_name           = "outshift-phoenix-ui"
   CSBApplicationName    = "outshift_ventures"
   CSBCiscoMailAlias     = "outshift-phoenix@cisco.com"
   CSBDataClassification = "Cisco Confidential"

--- a/aws_eticloud_us-east-2_s3_outshift-phoenix-project_main.tf
+++ b/aws_eticloud_us-east-2_s3_outshift-phoenix-project_main.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket = "eticloud-tf-state-nonprod"                                                       
-    key    = "terraform-state/aws-eticloud/s3/us-east-1/phoenix-ui.tfstate" 
+    key    = "terraform-state/aws-eticloud/s3/us-east-2/outshift-phoenix-ui.tfstate" 
     region = "us-east-2"                                                                       
   }
 }
@@ -37,7 +37,7 @@ provider "aws" {
 
 module "s3" {
   source                = "git::https://github.com/cisco-eti/sre-tf-module-aws-s3.git?ref=1.0.3"
-  bucket_name           = "phoenix-ui"
+  bucket_name           = "outshift-phoenix-ui"
   CSBApplicationName    = "outshift_ventures"
   CSBCiscoMailAlias     = "outshift-phoenix@cisco.com"
   CSBDataClassification = "Cisco Confidential"

--- a/aws_eticloud_us-east-2_s3_outshift-phoenix-project_main.tf
+++ b/aws_eticloud_us-east-2_s3_outshift-phoenix-project_main.tf
@@ -37,7 +37,7 @@ provider "aws" {
 
 module "s3" {
   source                = "git::https://github.com/cisco-eti/sre-tf-module-aws-s3.git?ref=1.0.3"
-  bucket_name           = "outshift-phoenix-ui"
+  bucket_name           = "phoenix-ui"
   CSBApplicationName    = "outshift_ventures"
   CSBCiscoMailAlias     = "outshift-phoenix@cisco.com"
   CSBDataClassification = "Cisco Confidential"

--- a/aws_eticloud_us-east-2_s3_outshift-phoenix-project_main.tf
+++ b/aws_eticloud_us-east-2_s3_outshift-phoenix-project_main.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket = "eticloud-tf-state-nonprod"                                                       
-    key    = "terraform-state/aws-eticloud/s3/us-east-2/outshift-phoenix-ui.tfstate" 
+    key    = "terraform-state/eticloud/s3/us-east-2/outshift-phoenix-ui.tfstate" 
     region = "us-east-2"                                                                       
   }
 }
@@ -36,7 +36,7 @@ provider "aws" {
 }
 
 module "s3" {
-  source                = "git::https://github.com/cisco-eti/sre-tf-module-aws-s3.git?ref=1.0.2"
+  source                = "git::https://github.com/cisco-eti/sre-tf-module-aws-s3.git?ref=1.0.3"
   bucket_name           = "outshift-phoenix-ui"
   CSBApplicationName    = "outshift_ventures"
   CSBCiscoMailAlias     = "outshift-phoenix@cisco.com"

--- a/aws_eticloud_us-east-2_s3_outshift-phoenix-project_main.tf
+++ b/aws_eticloud_us-east-2_s3_outshift-phoenix-project_main.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket = "eticloud-tf-state-nonprod"                                                       
-    key    = "terraform-state/aws-eticloud/s3/us-east-2/outshift-phoenix-ui.tfstate" 
+    key    = "terraform-state/aws-eticloud/s3/us-east-2/phoenix-ui.tfstate" 
     region = "us-east-2"                                                                       
   }
 }
@@ -37,7 +37,7 @@ provider "aws" {
 
 module "s3" {
   source                = "git::https://github.com/cisco-eti/sre-tf-module-aws-s3.git?ref=1.0.3"
-  bucket_name           = "outshift-phoenix-ui"
+  bucket_name           = "phoenix-ui"
   CSBApplicationName    = "outshift_ventures"
   CSBCiscoMailAlias     = "outshift-phoenix@cisco.com"
   CSBDataClassification = "Cisco Confidential"

--- a/aws_eticloud_us-east-2_s3_outshift-phoenix-project_main.tf
+++ b/aws_eticloud_us-east-2_s3_outshift-phoenix-project_main.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket = "eticloud-tf-state-nonprod"                                                       
-    key    = "terraform-state/eticloud/s3/us-east-2/phoenix-ui.tfstate" 
+    key    = "terraform-state/eticloud/s3/us-east-2/outshift-phoenix-ui.tfstate" 
     region = "us-east-2"                                                                       
   }
 }
@@ -37,7 +37,7 @@ provider "aws" {
 
 module "s3" {
   source                = "git::https://github.com/cisco-eti/sre-tf-module-aws-s3.git?ref=1.0.3"
-  bucket_name           = "phoenix-ui"
+  bucket_name           = "outshift-phoenix-ui"
   CSBApplicationName    = "outshift_ventures"
   CSBCiscoMailAlias     = "outshift-phoenix@cisco.com"
   CSBDataClassification = "Cisco Confidential"

--- a/aws_eticloud_us-east-2_s3_outshift-phoenix-project_main.tf
+++ b/aws_eticloud_us-east-2_s3_outshift-phoenix-project_main.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket = "eticloud-tf-state-nonprod"                                                       
-    key    = "terraform-state/eticloud/s3/us-east-2/outshift-phoenix-ui.tfstate" 
+    key    = "terraform-state/eticloud/s3/us-east-2/phoenix-ui.tfstate" 
     region = "us-east-2"                                                                       
   }
 }
@@ -37,7 +37,7 @@ provider "aws" {
 
 module "s3" {
   source                = "git::https://github.com/cisco-eti/sre-tf-module-aws-s3.git?ref=1.0.3"
-  bucket_name           = "outshift-phoenix-ui"
+  bucket_name           = "phoenix-ui"
   CSBApplicationName    = "outshift_ventures"
   CSBCiscoMailAlias     = "outshift-phoenix@cisco.com"
   CSBDataClassification = "Cisco Confidential"

--- a/aws_eticloud_us-east-2_s3_outshift-phoenix-project_main.tf
+++ b/aws_eticloud_us-east-2_s3_outshift-phoenix-project_main.tf
@@ -1,0 +1,47 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"                                                       
+    key    = "terraform-state/aws-eticloud/s3/us-east-1/phoenix-ui.tfstate" 
+    region = "us-east-2"                                                                       
+  }
+}
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+  alias     = "eticloud"
+}
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/eticloud/terraform_admin"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "outshift_ventures"
+      Component          = "phoenix"
+      CiscoMailAlias     = "outshift-phoenix@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "outshift-phoenix-admins"
+
+      IntendedPublic = "False"
+    }
+  }
+}
+
+module "s3" {
+  source                = "git::https://github.com/cisco-eti/sre-tf-module-aws-s3.git?ref=1.0.3"
+  bucket_name           = "outshift-phoenix-ui"
+  CSBApplicationName    = "outshift_ventures"
+  CSBCiscoMailAlias     = "outshift-phoenix@cisco.com"
+  CSBDataClassification = "Cisco Confidential"
+  CSBDataTaxonomy       = "Cisco Operations Data"
+  CSBEnvironment        = "NonProd"
+  CSBResourceOwner      = "outshift-phoenix-admins"
+}

--- a/aws_outshift-common-dev_iam_sso-roles_ventures-iam-roles_backend.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_ventures-iam-roles_backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "eticloud-tf-state-nonprod"
+    key            = "terraform-state/outshift-common-dev/iam/role/teams-sso-roles.tfstate"
+    region         = "us-east-2"
+    dynamodb_table = "eticloud-tf-locks"
+    encrypt        = true
+  }
+}

--- a/aws_outshift-common-dev_iam_sso-roles_ventures-iam-roles_provider.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_ventures-iam-roles_provider.tf
@@ -1,0 +1,19 @@
+provider "vault" {
+  address   = "https://keeper.cisco.com" # DON'T CHANGE THIS VALUE
+  namespace = "eticloud"                 # DON'T CHANGE THIS VALUE
+}
+
+locals {
+  account_name = "outshift-common-dev"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path = "secret/infra/aws/${local.account_name}/terraform_admin"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]     # DON'T CHANGE THIS VALUE
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"] # DON'T CHANGE THIS VALUE
+  region      = "us-east-2"                                                                 
+  max_retries = 3
+}

--- a/aws_outshift-common-dev_iam_sso-roles_ventures-iam-roles_roles.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_ventures-iam-roles_roles.tf
@@ -1,0 +1,176 @@
+module "a3po_role" {
+  source    = "../../../../../modules/sso-roles"
+  role_name = "a3po"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "a3po"
+    CiscoMailAlias  = "outshift-a3po@cisco.com"
+    ResourceOwner   = "a3po-admins"
+  }
+}
+
+module "action_engine_role" {
+  source    = "../../../../../modules/sso-roles"
+  role_name = "action-engine"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "action-engine"
+    CiscoMailAlias  = "action-engine-team@cisco.com"
+    ResourceOwner   = "action-engine-team"
+  }
+}
+
+module "aether_role" {
+  source    = "../../../../../modules/sso-roles"
+  role_name = "aether"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "aether"
+    CiscoMailAlias  = "outshift-aether@cisco.com"
+    ResourceOwner   = "aether-admins"
+  }
+}
+
+module "alfred_role" {
+  source    = "../../../../../modules/sso-roles"
+  role_name = "alfred"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "alfred"
+    CiscoMailAlias  = "outshift-alfred@cisco.com"
+    ResourceOwner   = "alfred-admins"
+  }
+}
+
+module "aqua_role" {
+  source    = "../../../../../modules/sso-roles"
+  role_name = "aqua"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "aqua"
+    CiscoMailAlias  = "aqua-team@cisco.com"
+    ResourceOwner   = "outshift-aqua-dev"
+  }
+}
+
+module "argus_role" {
+  source    = "../../../../../modules/sso-roles"
+  role_name = "argus"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "argus"
+    CiscoMailAlias  = "outshift-argus-dev@cisco.com"
+    ResourceOwner   = "outshift-argus-dev"
+  }
+}
+
+module "cascade_role" {
+  source    = "../../../../../modules/sso-roles"
+  role_name = "cascade"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "cascade"
+    CiscoMailAlias  = "chartsoo@cisco.com"
+    ResourceOwner   = "cil-splunk"
+  }
+}
+
+module "chef_role" {
+  source    = "../../../../../modules/sso-roles"
+  role_name = "chef"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "chef"
+    CiscoMailAlias  = "outshift-chef-team@cisco.com"
+    ResourceOwner   = "outshift-chef-team"
+  }
+}
+
+module "ioa_identity_role" {
+  source    = "../../../../../modules/sso-roles"
+  role_name = "ioa-identity"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "ioa_identity"
+    CiscoMailAlias  = "outshift-ioa-identity-team@cisco.com"
+    ResourceOwner   = "outshift-ioa-identity-team"
+  }
+}
+
+module "iridium_role" {
+  source    = "../../../../../modules/sso-roles"
+  role_name = "iridium"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "iridium"
+    CiscoMailAlias  = "outshift-iridium@cisco.com"
+    ResourceOwner   = "iridium-admins"
+  }
+}
+
+module "marvin_role" {
+  source    = "../../../../../modules/sso-roles"
+  role_name = "marvin"
+  tags = {
+    ApplicationName = "outshift_foundational_services"
+    Component       = "marvin"
+    CiscoMailAlias  = "marvin-outshift@cisco.com"
+    ResourceOwner   = "marvin-outshift"
+  }
+}
+
+module "ostinato_role" {
+  source    = "../../../../../modules/sso-roles"
+  role_name = "ostinato"
+  tags = {
+    ApplicationName = "outshift_foundational_services"
+    Component       = "ostinato"
+    CiscoMailAlias  = "ostinato-team-mailer@cisco.com"
+    Environment     = "NonProd"
+    ResourceOwner   = "ostinato-dev-team"
+  }
+}
+
+module "eti_website_role" {
+  source    = "../../../../../modules/sso-roles"
+  role_name = "eti-website"
+  tags = {
+    ApplicationName = "outshift_marketing"
+    Component       = "outshift_websites"
+    CiscoMailAlias  = "eti-websites@cisco.com"
+    ResourceOwner   = "eti-website-admins"
+  }
+}
+
+module "oval_role" {
+  source    = "../../../../../modules/sso-roles"
+  role_name = "oval"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "oval"
+    CiscoMailAlias  = "outshift-oval@cisco.com"
+    ResourceOwner   = "oval-admins"
+  }
+}
+
+module "phoenix_role" {
+  source    = "../../../../../modules/sso-roles"
+  role_name = "phoenix"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "phoenix"
+    CiscoMailAlias  = "outshift-phoenix@cisco.com"
+    ResourceOwner   = "outshift-phoenix-admins"
+  }
+}
+
+module "ragv2_role" {
+  source    = "../../../../../modules/sso-roles"
+  role_name = "ragv2"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "ragv2"
+    CiscoMailAlias  = "ragv2@cisco.com"
+    ResourceOwner   = "ragv2-team"
+  }
+}

--- a/aws_outshift-common-dev_iam_sso-roles_versions.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  required_version = ">= 1.5.5"
+}

--- a/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_main.tf
+++ b/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_main.tf
@@ -1,0 +1,57 @@
+terraform {
+  backend "s3" {
+    # This is the name of the backend S3 bucket.
+    bucket = "eticloud-tf-state-nonprod"
+    # This is the path to the Terraform state file in the backend S3 bucket.
+    key = "terraform-state/aws/eticloud/us-east-2/eks/comn-dev-use2-1.tfstate"
+    # This is the region where the backend S3 bucket is located.
+    region = "us-east-2" # DO NOT CHANGE.
+  }
+}
+
+locals {
+  name             = "comn-dev-use2-1"
+  region           = "us-east-2"
+  aws_account_name = "outshift-common-dev"
+  account_id       = "471112537430"
+  environment      = "dev"
+}
+
+module "eks_all_in_one" {
+  source = "git::https://github.com/cisco-eti/sre-tf-module-eks-allinone.git?ref=latest"
+
+  name             = local.name               # EKS cluster name
+  region           = local.region             # AWS provider region
+  aws_account_name = local.aws_account_name   # AWS account name
+  ami_id           = "ami-0d5d7695861cdaffe"  # AMI ID
+  cidr             = "10.0.0.0/16"            # VPC CIDR
+  cluster_version  = "1.31"                   # EKS cluster version
+
+  # EKS Managed Private Node Group
+  instance_types = ["m6a.2xlarge"] # EKS instance types
+  min_size       = 6               # EKS node group min size
+  max_size       = 6               # EKS node group max size
+  desired_size   = 6               # EKS node group desired size
+
+
+  # Karpenter
+  create_karpenter_irsa = true # Create Karpenter IRSA
+
+  additional_aws_auth_configmap_roles = [
+    {
+      rolearn  = "arn:aws:iam::${local.account_id}:user/terraform_admin",
+      username = "terraform_admin",
+      groups   = ["system:masters"]
+    }
+    , {
+      rolearn  = "arn:aws:iam::${local.account_id}:role/devops",
+      username = "devops",
+      groups   = ["system:masters"]
+    }
+    , {
+      rolearn  = "arn:aws:iam::${local.account_id}:role/cluster-access",
+      username = "cluster-access",
+      groups   = ["system:masters"]
+    }
+  ]
+}

--- a/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-rag-dev-1_backend.tf
+++ b/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-rag-dev-1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aurora-postgres/us-east-2/ostinato-rag-dev-1.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-rag-dev-1_locals.tf
+++ b/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-rag-dev-1_locals.tf
@@ -1,0 +1,7 @@
+
+locals {
+  vpc_name = "common-dev-use2-vpc-data"
+  cluster_vpc_name = "comn-dev-use2-1"
+  aws_account_name = "outshift-common-dev"
+  rds_name  = "ostinato-rag-dev-1"
+}

--- a/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-rag-dev-1_main.tf
+++ b/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-rag-dev-1_main.tf
@@ -1,0 +1,22 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+  provider = vault.eticloud
+}
+
+data "aws_vpc" "cluster_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = [local.cluster_vpc_name]
+  }
+}
+
+module "rds" {
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=1.1.0"
+  vpc_name          = local.vpc_name
+  database_name     = "rag"
+  db_instance_type  = "db.r7g.xlarge"
+  cluster_name      = local.rds_name
+  secret_path       = "secret/eticcprod/infra/aurora-pg/us-east-2/outshift-common-dev/ostinato-rag-dev-1"
+  db_allowed_cidrs  = [data.aws_vpc.cluster_vpc.cidr_block]
+  db_engine_version = "15"
+}

--- a/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-rag-dev-1_providers.tf
+++ b/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-rag-dev-1_providers.tf
@@ -1,0 +1,23 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "outshift_foundational_services"
+      Component          = "rag"
+      CiscoMailAlias     = "ostinato-team-mailer@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ostinato-dev-team"
+    }
+  }
+}

--- a/aws_outshift-common-dev_us-east-2_s3_outshift-phoenix-project_main.tf
+++ b/aws_outshift-common-dev_us-east-2_s3_outshift-phoenix-project_main.tf
@@ -1,0 +1,47 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"                                                       # We separate the different levels of development into different buckets. The buckets are eticloud-tf-state-sandbox, eticloud-tf-state-nonprod, eticloud-tf-state-prod. The environment should match the CSBEnvironment below.
+    key    = "terraform-state/outshift-common-dev/us-east-2/s3/phoenix-ui.tfstate" # #note the path here. It should match the pattern terraform_state/<service>/<region>/<name>.tfstate
+    region = "us-east-2"                                                                       # Do not change without talking to the SRE team.
+  }
+}
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+  alias     = "eticloud"
+}
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/outshift-common-dev/terraform_admin"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "outshift_ventures"
+      Component          = "phoenix"
+      CiscoMailAlias     = "outshift-phoenix@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "outshift-phoenix-admins"
+
+      IntendedPublic = "False"
+    }
+  }
+}
+
+module "s3" {
+  source                = "git::https://github.com/cisco-eti/sre-tf-module-aws-s3.git?ref=1.0.3"
+  bucket_name           = "phoenix-ui"
+  CSBApplicationName    = "outshift_ventures"
+  CSBCiscoMailAlias     = "outshift-phoenix@cisco.com"
+  CSBDataClassification = "Cisco Confidential"
+  CSBDataTaxonomy       = "Cisco Operations Data"
+  CSBEnvironment        = "NonProd"
+  CSBResourceOwner      = "outshift-phoenix-admins"
+}

--- a/aws_outshift-common-dev_us-east-2_s3_outshift-phoenix-project_main.tf
+++ b/aws_outshift-common-dev_us-east-2_s3_outshift-phoenix-project_main.tf
@@ -37,7 +37,7 @@ provider "aws" {
 
 module "s3" {
   source                = "git::https://github.com/cisco-eti/sre-tf-module-aws-s3.git?ref=1.0.3"
-  bucket_name           = "phoenix-ui"
+  bucket_name           = "outshift-phoenix-ui"
   CSBApplicationName    = "outshift_ventures"
   CSBCiscoMailAlias     = "outshift-phoenix@cisco.com"
   CSBDataClassification = "Cisco Confidential"

--- a/aws_outshift-common-dev_us-east-2_s3_outshift-phoenix-project_main.tf
+++ b/aws_outshift-common-dev_us-east-2_s3_outshift-phoenix-project_main.tf
@@ -1,8 +1,8 @@
 terraform {
   backend "s3" {
-    bucket = "eticloud-tf-state-nonprod"                                                       # We separate the different levels of development into different buckets. The buckets are eticloud-tf-state-sandbox, eticloud-tf-state-nonprod, eticloud-tf-state-prod. The environment should match the CSBEnvironment below.
-    key    = "terraform-state/outshift-common-dev/us-east-2/s3/phoenix-ui.tfstate" # #note the path here. It should match the pattern terraform_state/<service>/<region>/<name>.tfstate
-    region = "us-east-2"                                                                       # Do not change without talking to the SRE team.
+    bucket = "eticloud-tf-state-nonprod"                                                       
+    key    = "terraform-state/outshift-common-dev/us-east-2/s3/phoenix-ui.tfstate" 
+    region = "us-east-2"                                                                       
   }
 }
 provider "vault" {

--- a/aws_outshift-common-dev_us-east-2_s3_rag-raw-documents-dev_main.tf
+++ b/aws_outshift-common-dev_us-east-2_s3_rag-raw-documents-dev_main.tf
@@ -1,0 +1,49 @@
+# This file was created by Outshift Platform Self-Service automation.
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"                                                      # We separate the different levels of development into different buckets. The buckets are eticloud-tf-state-sandbox, eticloud-tf-state-nonprod, eticloud-tf-state-prod. The environment should match the CSBEnvironment below.
+    key    = "terraform-state/outshift-common-dev/us-east-2/s3/rag-raw-documents-dev.tfstate" # #note the path here. It should match the pattern terraform_state/<service>/<region>/<name>.tfstate
+    region = "us-east-2"                                                                      # Do not change without talking to the SRE team.
+  }
+}
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+  alias     = "eticloud"
+}
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/outshift-common-dev/terraform_admin"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "RAG"
+      Component          = "ostinato_rag"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Restricted"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "darrelau@cisco.com"
+
+      IntendedPublic = "False"
+
+    }
+  }
+}
+
+module "s3" {
+  source                = "git::https://wwwin-github.cisco.com/eti/sre-tf-module-aws-s3.git?ref=1.0.2"
+  bucket_name           = "rag-raw-documents-dev"
+  CSBApplicationName    = "RAG"
+  CSBCiscoMailAlias     = "eti-sre-admins@cisco.com"
+  CSBDataClassification = "Cisco Restricted"
+  CSBDataTaxonomy       = "Cisco Operations Data"
+  CSBEnvironment        = "NonProd"
+  CSBResourceOwner      = "darrelau@cisco.com"
+}

--- a/modules_sso-roles_data.tf
+++ b/modules_sso-roles_data.tf
@@ -1,0 +1,33 @@
+data "aws_caller_identity" "current" {}
+
+# IAM Policies
+data "aws_iam_policy_document" "assume_role_with_saml" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRoleWithSAML"]
+
+    principals {
+      type = "Federated"
+
+      identifiers = ["arn:aws:iam::${local.account_id}:saml-provider/cloudsso.cisco.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "SAML:aud"
+      values   = ["https://signin.aws.amazon.com/saml"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+    principals {
+      type = "AWS"
+
+      identifiers = ["arn:aws:iam::${local.account_id}:root"]
+    }
+  }
+}

--- a/modules_sso-roles_locals.tf
+++ b/modules_sso-roles_locals.tf
@@ -1,0 +1,3 @@
+locals {
+  account_id   = data.aws_caller_identity.current.account_id
+}

--- a/modules_sso-roles_main.tf
+++ b/modules_sso-roles_main.tf
@@ -1,0 +1,13 @@
+# IAM role 
+resource "aws_iam_role" "this" {
+  name                 = var.role_name
+  max_session_duration = "3600"
+  assume_role_policy   = data.aws_iam_policy_document.assume_role_with_saml.json
+  tags                 = var.tags
+}
+
+# Attach PowerUserAccess AWS Managed Policy 
+resource "aws_iam_role_policy_attachment" "power_user_access_policy_attachment" {
+  role       = aws_iam_role.this.name
+  policy_arn = var.policy_arn
+}

--- a/modules_sso-roles_variables.tf
+++ b/modules_sso-roles_variables.tf
@@ -1,0 +1,14 @@
+variable "role_name" {
+  description = "Name of the IAM role"
+  type        = string
+}
+
+variable "policy_arn" {
+  description = "ARN of the PowerUserAccess AWS managed policy to attach to the role"
+  type        = string
+  default = "arn:aws:iam::aws:policy/PowerUserAccess"
+}
+variable "tags" {
+  description = "Tags to apply to the IAM roles"
+  type        = map(string)
+}

--- a/modules_sso-roles_versions.tf
+++ b/modules_sso-roles_versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  required_version = ">= 1.5.5"
+}


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  
https://cisco-eti.atlassian.net/browse/PHI-446

### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [ ] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
